### PR TITLE
Added new fancyProp for type to support Internet Explorer

### DIFF
--- a/fancyProps.js
+++ b/fancyProps.js
@@ -98,5 +98,11 @@ module.exports = {
         for(var key in value){
             element.style[key] = value[key];
         }
+    },
+    type: function(generic, element, value){
+        if(arguments.length === 2){
+            return element.type;
+        }
+        element.setAttribute('type', value);
     }
 };


### PR DESCRIPTION
Was giving error with "Invalid argument." on element[key] = value (genericComponent.js 107)